### PR TITLE
Add third-party license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # tinytls
+
 tiny tls library
+
+## Third-Party Licenses
+
+Some code under `crypto/` originates from the *wpa_supplicant* project by
+Jouni Malinen. These files carry a dual BSD/GPLv2 license header and refer to
+the original `README` and `COPYING` texts from that project. Those license
+texts are not included in this repository, so please consult the upstream
+project when redistributing tinytls.
+
+All other code in this repository is released under the MIT License (see
+`LICENSE`).


### PR DESCRIPTION
## Summary
- document that crypto/ files originate from wpa_supplicant
- clarify third-party licensing in the README

## Testing
- `make test` *(fails: No rule to make target 'test')*